### PR TITLE
sweep /\n\s+/ and join related lines from the beginning

### DIFF
--- a/negative-look-ahead-vs-loop-exactly-match.pl
+++ b/negative-look-ahead-vs-loop-exactly-match.pl
@@ -57,12 +57,21 @@ sub la {
     return $v;
 }
 
+sub sr {
+    my $v = {};
+    %$v = map { split /:\s*/, $_, 2 }
+          split /\n/, $Headers2 =~ s/\n\s+/ /gr;
+    return $v;
+}
+
 my $re = em();
 my $rl = la();
+my $sr = sr();
 print Data::Dumper::Dumper $re;
 print Data::Dumper::Dumper $rl;
+print Data::Dumper::Dumper $sr;
 
-for my $e ( $re, $rl ) {
+for my $e ( $re, $rl, $sr ) {
     is $e->{'Diagnostic-Code'}, 'SMTP; 550 5.1.1 The user does not exist in virtual mailbox list of our server';
     is $e->{'Action'}, 'failed';
     is $e->{'Remote-MTA'}, 'DNS; mx.example.jp';
@@ -74,6 +83,7 @@ printf("Running with Perl %s on %s\n%s\n", $^V, $^O, '-' x 80);
 cmpthese(6e5, {
         'for $e =~ /.../' => sub { em() },
         '%e =~ /...(?!)/' => sub { la() },
+        'map{split}split' => sub { sr() },
     }
 );
 


### PR DESCRIPTION
`la()` では `\n\s+` を実質的に後の方で掃除しているのですが、先に掃除すれば1行が必ずキーバリューのペアになってデータがある種の正規化がなされて見通しが良くなってかつ早いのではないかという仮説から `sr()` を書いてみました。

`la()` sweeps `\n\s+` at the end.
I write `sr()` which sweeps `\n\s+` in the beginning.

```pl
sub sr {
    my $v = {};
    %$v = map { split /:\s*/, $_, 2 }
          split /\n/, $Headers2 =~ s/\n\s+/ /gr;
    return $v;
}
```

手元での結果は以下。

Following is result by my machine.

```
$ perl negative-look-ahead-vs-loop-exactly-match.pl
$VAR1 = {
          'Diagnostic-Code' => 'SMTP; 550 5.1.1 The user does not exist in virtual mailbox list of our server',
          'Status' => '5.1.1',
          'Final-Recipient' => 'RFC822; neko@example.jp',
          'Remote-MTA' => 'DNS; mx.example.jp',
          'Action' => 'failed'
        };
$VAR1 = {
          'Action' => 'failed',
          'Remote-MTA' => 'DNS; mx.example.jp',
          'Final-Recipient' => 'RFC822; neko@example.jp',
          'Status' => '5.1.1',
          'Diagnostic-Code' => 'SMTP; 550 5.1.1 The user does not exist in virtual mailbox list of our server'
        };
$VAR1 = {
          'Status' => '5.1.1',
          'Last-Attempt-Date' => 'Thu, 6 Jul 2017 20:27:19 +0900',
          'Final-Recipient' => 'RFC822; neko@example.jp',
          'Diagnostic-Code' => 'SMTP; 550 5.1.1 The user does not exist in virtual mailbox list of our server',
          'Remote-MTA' => 'DNS; mx.example.jp',
          'Action' => 'failed'
        };
ok 1
ok 2
ok 3
ok 4
ok 5
ok 6
ok 7
ok 8
ok 9
ok 10
ok 11
ok 12
ok 13
ok 14
ok 15
Running with Perl v5.30.0 on darwin
--------------------------------------------------------------------------------
                    Rate for $e =~ /.../ map{split}split %e =~ /...(?!)/
for $e =~ /.../  57582/s              --            -50%            -58%
map{split}split 114068/s             98%              --            -17%
%e =~ /...(?!)/ 137931/s            140%             21%              --
1..15
```

元の `for $e =~ /.../` より早いですが、否定先読みの `%e =~ /...(?!)/` には及ばないようでした。
新たな文字列を `s///r` や `split /\n/` で都度作っていくステップが響いているのかもしれません。

It is faster than `for $e =~ /.../`, but it is slower than `%e =~ /...(?!)/`.
It may be few heavy to making new string each times as `s///r` and `split /\n/`.
